### PR TITLE
support custom header key option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,16 @@ server.route({
   path: '/array',
   handler: {
     versioned: [
-      reply({
-        version: '1.0'
-      }),
-      reply({
-        version: '2.0'
-      })
+      function(request, reply) {
+        reply({
+          version: '1.0'
+        });
+      },
+      function(request, reply) {
+        reply({
+          version: '2.0'
+        });
+      }
     ]
   }
 });
@@ -75,17 +79,23 @@ server.route({
     path: '/object',
     handler: {
       versioned: {
-        'v1.0': reply({
-          version: '1.0'
-        }),
+        'v1.0': function(request, reply) {
+          reply({
+            version: '1.0'
+          });
+        },
 
-        'v2.0': reply({
-          version: '2.0'
-        }),
+        'v2.0': function(request, reply) {
+          reply({
+            version: '2.0'
+          });
+        },
 
-        'v1.5': reply({
-          version: '1.5'
-        })
+        'v1.5': function(request, reply) {
+          reply({
+            version: '1.5'
+          });
+        }
       }
     }
 });

--- a/README.md
+++ b/README.md
@@ -10,21 +10,19 @@ A hapi.js plugin for versioning your API. Borne out of this talk: http://www.sli
 
 `npm install consistency`
 
-##Register plugin with your hapi application
+##Register plugin with your hapi application, provide the option(s) required for version detection.
 
 ```js
 server.register({
   register: require('consistency'),
   options: {
-    uriVersioning: true,
-    customHeaderVersioning: true,
-    acceptHeaderVersioning: true,
+    uriParam: 'apiVersion',
     acceptNamespace: 'consistencyExample',
     customHeaderKey: 'api-version'
   }
 }, function (err) {
   if (err) console.log('Consistency plugin failed to load');
-  
+
 });
 ```
 
@@ -48,4 +46,3 @@ Glue.compose(manifest, function (err, server) {
   ...
 });
 ```
-

--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ var manifest = {
   connections: [...],
   plugins: {
     consistency: {
-      uriVersioning: true,
-      customHeaderVersioning: true,
-      acceptHeaderVersioning: true,
+      uriParam: 'apiVersion',
       acceptNamespace: 'consistencyExample',
       customHeaderKey: 'api-version'
     }
@@ -46,3 +44,66 @@ Glue.compose(manifest, function (err, server) {
   ...
 });
 ```
+
+##Versionize your Routes
+
+###Array of handlers
+```
+server.route({
+  id: 'array',
+  method: 'GET',
+  path: '/array',
+  handler: {
+    versioned: [
+      reply({
+        version: '1.0'
+      }),
+      reply({
+        version: '2.0'
+      })
+    ]
+  }
+});
+```
+
+###Object of handlers
+
+```
+server.route({
+    id: 'object',
+    method: 'GET',
+    path: '/object',
+    handler: {
+      versioned: {
+        'v1.0': reply({
+          version: '1.0'
+        }),
+
+        'v2.0': reply({
+          version: '2.0'
+        }),
+
+        'v1.5': reply({
+          version: '1.5'
+        })
+      }
+    }
+});
+```
+
+##Version Matching
+
+A version can be provided with or without the v prefix and can also be provided
+using the `latest` keyword which will use the latest versioned endpoint.
+
+Matching of version handlers is cached to remove redundent checks based on the
+route method and route path.  
+
+If an endpoint has not changed in a specific version of the api, we can omit it
+and the matcher will use the version that is closest to the one request. for example
+if in version 2 we didn't update the users endpoint a request would return version
+1
+
+If you provide the version in shorthand (v1, 1) it will return greatest version available
+for that api version. for example given the versions 1, 1.2, 1.5 providing 1 will return
+1.5.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Glue.compose(manifest, function (err, server) {
 ##Versionize your Routes
 
 ###Array of handlers
-```
+```js
 server.route({
   id: 'array',
   method: 'GET',
@@ -72,7 +72,7 @@ server.route({
 
 ###Object of handlers
 
-```
+```js
 server.route({
     id: 'object',
     method: 'GET',

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -3,11 +3,11 @@
 var _ = require('lodash');
 var cache = {};
 
-function versionToFloat(v) {
+function versionToFloat(v, noShorthand) {
   if (_.isString(v)) {
     v = v.replace('v', '');
 
-    if (v.length == 1) {
+    if (! noShorthand && v.length == 1) {
       v = v + '.99';
     }
   }
@@ -51,7 +51,7 @@ module.exports = function register(server) {
     var versions = {};
 
     _.each(handlers, function(handler, version) {
-      version = versionToFloat(version);
+      version = versionToFloat(version, true);
 
       if (handlersIsArray) {
         version += 1;

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -1,0 +1,79 @@
+'use strict';
+
+var _ = require('lodash');
+var cache = {};
+
+function versionToFloat(v) {
+  if (_.isString(v)) {
+    v = v.replace('v', '');
+
+    if (v.length == 1) {
+      v = v + '.99';
+    }
+  }
+
+  return parseFloat(v);
+}
+
+function cachedVersion(id, version) {
+  return cache[id] && cache[id][version];
+}
+
+function detectVersionHandler(id, version, handlers) {
+  var handler;
+  var versions = Object.keys(handlers).sort()
+                                      .reverse();
+
+  _.some(versions, function testVersion(v) {
+    if (v <= version) {
+      handler = handlers[v];
+    }
+
+    return handler;
+  });
+
+  cacheVersionHandler(id, version, handler);
+
+  return handler;
+}
+
+function cacheVersionHandler(id, version, handler) {
+  if (id) {
+    cache[id] = cache[id] || {};
+    cache[id][version] = handler;
+  }
+}
+
+module.exports = function register(server) {
+  server.handler('versioned', function(route, handlers) {
+    var id = route.method + '::' + route.path;
+    var handlersIsArray = _.isArray(handlers);
+    var versions = {};
+
+    _.each(handlers, function(handler, version) {
+      version = versionToFloat(version);
+
+      if (handlersIsArray) {
+        version += 1;
+      }
+
+      versions[version] = handler;
+    });
+
+    var latest = Object.keys(versions).sort().pop();
+
+    versions.latest = versions[latest];
+
+    return function(request, reply) {
+      var input = request.plugins.consistency.apiVersion;
+      var version = input !== 'latest' ? versionToFloat(input) : latest;
+      var handler = cachedVersion(id, version);
+
+      if (! handler) {
+         handler = detectVersionHandler(id, version, versions)
+      }
+
+      return handler(request, reply);
+    };
+  });
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,6 @@ exports.register = function (server, options, next) {
     var headerKey = options.customHeaderKey;
     var headers = request.headers;
     var acceptNamespace = options.acceptNamespace;
-    var versionPattern = /v[0-9]+(\.[0-9]+)?/;
     var acceptPattern = new RegExp('^application\/vnd\.' + acceptNamespace + '\.');
     var version;
 
@@ -33,7 +32,6 @@ exports.register = function (server, options, next) {
     return reply.continue();
 
   });
-
 
   handler(server, options);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,8 +10,8 @@ exports.register = function (server, options, next) {
     }
 
     // Custom Header Versioning, if enabled
-    if (options.customHeaderVersioning && request.headers['api-version'] && (/^[0-9]+$/).test(request.headers['api-version']) ) {
-      request.plugins.consistency.apiVersion = 'v' + request.headers['api-version'];
+    if (options.customHeaderVersioning && request.headers[options.customHeaderKey] && (/^[0-9]+$/).test(request.headers[options.customHeaderKey]) ) {
+      request.plugins.consistency.apiVersion = 'v' + request.headers[options.customHeaderKey];
       return reply.continue();
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,24 +1,30 @@
 exports.register = function (server, options, next) {
 
   server.ext('onPreHandler', function (request, reply) {
+    var uriParam = options.uriParam;
+    var params = request.params;
+    var headerKey = options.customHeaderKey;
+    var headers = request.headers;
+    var acceptNamespace = options.acceptNamespace;
+
     request.plugins.consistency = {};
 
     // URI versioning, if enabled
-    if (options.uriVersioning && request.params.apiVersion && (/^v[0-9]+$/).test(request.params.apiVersion) ) {
-      request.plugins.consistency.apiVersion = request.params.apiVersion;
+    if (uriParam && params[uriParam] && (/^v[0-9]+$/).test(params[uriParam]) ) {
+      request.plugins.consistency.apiVersion = params[uriParam];
       return reply.continue();
     }
 
     // Custom Header Versioning, if enabled
-    if (options.customHeaderVersioning && request.headers['api-version'] && (/^[0-9]+$/).test(request.headers['api-version']) ) {
-      request.plugins.consistency.apiVersion = 'v' + request.headers['api-version'];
+    if (headerKey && headers[headerKey] && (/^[0-9]+$/).test(headers[headerKey]) ) {
+      request.plugins.consistency.apiVersion = 'v' + headers[headerKey];
       return reply.continue();
     }
 
     // Accept Header Versioning, if enabled
-    var pattern = new RegExp('^application\/vnd\.' + options.acceptNamespace + '\.v[0-9]+$');
-    if (options.acceptHeaderVersioning && request.headers['accept'] && pattern.test(request.headers['accept'])) {
-      request.plugins.consistency.apiVersion = request.headers['accept'].replace('application/vnd.' + options.acceptNamespace + '.', '');
+    var pattern = new RegExp('^application\/vnd\.' + acceptNamespace + '\.v[0-9]+$');
+    if (acceptNamespace && headers['accept'] && pattern.test(headers['accept'])) {
+      request.plugins.consistency.apiVersion = headers['accept'].replace('application/vnd.' + acceptNamespace + '.', '');
       return reply.continue();
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,38 +1,41 @@
+'use strict';
+
+var handler = require('./handler');
+
 exports.register = function (server, options, next) {
 
   server.ext('onPreHandler', function (request, reply) {
     var uriParam = options.uriParam;
-    var params = request.params;
+    var params = request.params || {};
     var headerKey = options.customHeaderKey;
     var headers = request.headers;
     var acceptNamespace = options.acceptNamespace;
+    var versionPattern = /v[0-9]+(\.[0-9]+)?/;
+    var acceptPattern = new RegExp('^application\/vnd\.' + acceptNamespace + '\.');
+    var version;
 
     request.plugins.consistency = {};
 
     // URI versioning, if enabled
-    if (uriParam && params[uriParam] && (/^v[0-9]+$/).test(params[uriParam]) ) {
-      request.plugins.consistency.apiVersion = params[uriParam];
-      return reply.continue();
+    if (uriParam && params[uriParam]) {
+      version = params[uriParam];
+    } else if (headerKey && headers[headerKey]) {
+      version = headers[headerKey];
+    } else if (acceptNamespace && headers['accept'] && acceptPattern.test(headers['accept'])) {
+      version = headers['accept'].replace('application/vnd.' + acceptNamespace + '.', '');
+    } else {
+      version = 'latest';
     }
 
-    // Custom Header Versioning, if enabled
-    if (headerKey && headers[headerKey] && (/^[0-9]+$/).test(headers[headerKey]) ) {
-      request.plugins.consistency.apiVersion = 'v' + headers[headerKey];
-      return reply.continue();
-    }
+    // Default to latest
+    request.plugins.consistency.apiVersion = version;
 
-    // Accept Header Versioning, if enabled
-    var pattern = new RegExp('^application\/vnd\.' + acceptNamespace + '\.v[0-9]+$');
-    if (acceptNamespace && headers['accept'] && pattern.test(headers['accept'])) {
-      request.plugins.consistency.apiVersion = headers['accept'].replace('application/vnd.' + acceptNamespace + '.', '');
-      return reply.continue();
-    }
-
-    // Default
-    request.plugins.consistency.apiVersion = 'v1';
     return reply.continue();
 
   });
+
+
+  handler(server, options);
 
   next();
 

--- a/package.json
+++ b/package.json
@@ -20,5 +20,13 @@
   "bugs": {
     "url": "https://github.com/shakefon/consistency/issues"
   },
-  "homepage": "https://github.com/shakefon/consistency"
+  "homepage": "https://github.com/shakefon/consistency",
+  "dependencies": {
+    "lodash": "^3.5.0"
+  },
+  "devDependencies": {
+    "code": "^1.3.0",
+    "hapi": "^8.4.0",
+    "lab": "^5.5.0"
+  }
 }

--- a/test/server.js
+++ b/test/server.js
@@ -42,7 +42,7 @@ server.register({
       path: '/test',
       handler: {
         versioned: {
-          'v1.0': reply({
+          'v1': reply({
             version: '1.0'
           }),
 

--- a/test/server.js
+++ b/test/server.js
@@ -1,0 +1,81 @@
+var Hapi = require('hapi');
+var consistency = require('../lib');
+var server = new Hapi.Server();
+
+
+function reply(obj) {
+  return function(req, rep) {
+    rep(obj);
+  }
+}
+
+server.connection({ port: 3000 });
+
+server.register({
+  register: consistency,
+  options: {
+    uriParam: 'apiVersion',
+    acceptNamespace: 'example',
+    customHeaderKey: 'api-version'
+  }
+}, function registerRoutes() {
+  server.route({
+      method: 'GET',
+      path: '/array',
+      handler: {
+        versioned: [
+          reply({
+            version: '1.0'
+          }),
+          reply({
+            version: '2.0'
+          }),
+          reply({
+            version: '3.0'
+          })
+        ]
+      }
+  });
+
+  server.route({
+      method: 'GET',
+      path: '/test',
+      handler: {
+        versioned: {
+          'v1.0': reply({
+            version: '1.0'
+          }),
+
+          'v2.0': reply({
+            version: '2.0'
+          }),
+
+          'v1.5': reply({
+            version: '1.5'
+          })
+        }
+      }
+  });
+
+  server.route({
+      method: 'GET',
+      path: '/url/{apiVersion?}',
+      handler: {
+        versioned: {
+          'v1.0': reply({
+            version: '1.0'
+          }),
+
+          'v2.0': reply({
+            version: '2.0'
+          }),
+
+          'v1.5': reply({
+            version: '1.5'
+          })
+        }
+      }
+  });
+});
+
+module.exports = server;

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,0 +1,227 @@
+'use strict';
+
+var _          = require('lodash');
+var Lab        = require('lab');
+var expect     = require('code').expect;
+var lab        = Lab.script();
+var describe   = lab.describe;
+var it         = lab.it;
+var beforeEach = lab.beforeEach;
+var afterEach  = lab.afterEach;
+var server     = require('./server');
+
+function runTests(options, version, done) {
+  server.inject(options, function (res) {
+    var response = res.result.version;
+    expect(response).to.exist();
+    expect(response).to.be.a.string()
+    expect(parseFloat(response)).to.equal(version);
+    done();
+  });
+}
+
+describe('Versioning', function() {
+  describe('custom header', function() {
+    it('should get version', function(done) {
+      runTests({
+        url: '/url/v1.0'
+      }, 1.0, done);
+    });
+
+    it('should get version (shorthand)', function(done) {
+      runTests({
+        url: '/url/v1'
+      }, 1.5, done);
+    });
+
+    it('should return closest version matching if version', function(done) {
+      runTests({
+        url: '/url/v3.0'
+      }, 2.0, done);
+    });
+
+    it('should be optional to provide the v', function(done) {
+      runTests({
+        url: '/url/1.5'
+      }, 1.5, done);
+    });
+
+    it('should allow latest as version', function(done) {
+      runTests({
+        url: '/test',
+        headers: {
+          'api-version': 'latest'
+        }
+      }, 2.0, done);
+    });
+
+    it('should default to the latest if not provided', function(done) {
+      runTests({
+        url: '/url/'
+      }, 2.0, done);
+    });
+  });
+
+  describe('custom header', function() {
+    it('should get version', function(done) {
+      runTests({
+        url: '/test',
+        headers: {
+          'api-version': 'v1.0'
+        }
+      }, 1.0, done);
+    });
+
+    it('should get version (shorthand)', function(done) {
+      runTests({
+        url: '/test',
+        headers: {
+          'api-version': 'v1'
+        }
+      }, 1.5, done);
+    });
+
+    it('should return closest version matching if version', function(done) {
+      runTests({
+        url: '/test',
+        headers: {
+          'api-version': 'v3.0'
+        }
+      }, 2.0, done);
+    });
+
+    it('should be optional to provide the v', function(done) {
+      runTests({
+        url: '/test',
+        headers: {
+          'api-version': '1.5'
+        }
+      }, 1.5, done);
+    });
+
+    it('should allow latest as version', function(done) {
+      runTests({
+        url: '/test',
+        headers: {
+          'api-version': 'latest'
+        }
+      }, 2.0, done);
+    });
+
+    it('should default to the latest if not provided', function(done) {
+      runTests({
+        url: '/test'
+      }, 2.0, done);
+    });
+  });
+
+  describe('accept header', function() {
+    var header = 'application/vnd.example.';
+
+    it('should get version', function(done) {
+      runTests({
+        url: '/test',
+        headers: {
+          'accept': header + 'v1.0'
+        }
+      }, 1.0, done);
+    });
+
+    it('should get version (shorthand)', function(done) {
+      runTests({
+        url: '/test',
+        headers: {
+          'accept': header + 'v1'
+        }
+      }, 1.5, done);
+    });
+
+    it('should return closest version matching if version', function(done) {
+      runTests({
+        url: '/test',
+        headers: {
+          'accept': header + 'v3.0'
+        }
+      }, 2.0, done);
+    });
+
+    it('should be optional to provide the v', function(done) {
+      runTests({
+        url: '/test',
+        headers: {
+          'accept': header + '1.5'
+        }
+      }, 1.5, done);
+    });
+
+    it('should allow latest as version', function(done) {
+      runTests({
+        url: '/test',
+        headers: {
+          'accept': header + 'latest'
+        }
+      }, 2.0, done);
+    });
+
+    it('should default to the latest if not provided', function(done) {
+      runTests({
+        url: '/test'
+      }, 2.0, done);
+    });
+  });
+
+  describe('Works with array of handlers', function() {
+    it('should get version', function(done) {
+      runTests({
+        url: '/array',
+        headers: {
+          'api-version': 'v1.0'
+        }
+      }, 1.0, done);
+    });
+
+    it('should get version (shorthand)', function(done) {
+      runTests({
+        url: '/array',
+        headers: {
+          'api-version': 'v2'
+        }
+      }, 2.0, done);
+    });
+
+    it('should return closest version matching if version', function(done) {
+      runTests({
+        url: '/array',
+        headers: {
+          'api-version': 'v4.0'
+        }
+      }, 3.0, done);
+    });
+
+    it('should be optional to provide the v', function(done) {
+      runTests({
+        url: '/array',
+        headers: {
+          'api-version': '1'
+        }
+      }, 1, done);
+    });
+
+    it('should allow latest as version', function(done) {
+      runTests({
+        url: '/array',
+        headers: {
+          'api-version': 'latest'
+        }
+      }, 3.0, done);
+    });
+
+    it('should default to the latest if not provided', function(done) {
+      runTests({
+        url: '/array'
+      }, 3.0, done);
+    });
+  });
+});
+
+module.exports.lab = lab;


### PR DESCRIPTION
This turned into more of a redesign then a bugfix, look it over see if it fits your vision for the plugin.
- Added a 'versioned' handler that automatically routes to the specified versions, with caching to avoid redetection of versions
- Added tests
- Allow for latest as a version option
- Make the v optional prefix
- Hookup customHeaderKey option
- Removed verbosity of optoins, since each method requires a parameter if provided its active
- Allow for shorthand v1 maps to latest v1 api (ie: v1.5)
- Omitting a version provides the latest version (could add option to throw if omitted)
- If version doesn't exist (1.5) will find closes (1), so that we don't have to duplicate code for endpoints that do not require another version
- Updated Readme
